### PR TITLE
Add CI/CD workflow from gautada/cicd container template

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,58 @@
+---
+name: "Continuous Integration: Build and Publish Multi-Architecture Container Images"
+# This is the generic reusable template for building containers
+
+'on':
+  workflow_dispatch: {}
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    uses: gautada/cicd/.github/workflows/ci-linter.yaml@main
+  build-arm64:
+    needs: check
+    uses: gautada/cicd/.github/workflows/ci-podman-build.yaml@main
+    with:
+      architecture: "arm64"
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  build-amd64:
+    needs: check
+    uses: gautada/cicd/.github/workflows/ci-podman-build.yaml@main
+    with:
+      architecture: "amd64"
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  publish:
+    needs: [build-arm64, build-amd64]
+    uses: gautada/cicd/.github/workflows/ci-podman-publish.yaml@main
+    with:
+      architectures: '["arm64", "amd64"]'
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  clean:
+    needs: [publish]
+    uses: gautada/cicd/.github/workflows/ci-registry-clean.yaml@main
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  test:
+    needs: [clean]
+    uses: gautada/cicd/.github/workflows/ci-container-test.yaml@main
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  release:
+    needs: [test]
+    uses: gautada/cicd/.github/workflows/cd-tag-latest.yaml@main
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/cicd.yaml` from the `gautada/cicd` container template to enable automated CI/CD for this repository.

References #5